### PR TITLE
修复无法拉取 pr 到当前分支

### DIFF
--- a/source/internal/repo.ts
+++ b/source/internal/repo.ts
@@ -207,9 +207,10 @@ export class RepoTask extends Task {
                     const {
                         url, targetValue, local,
                     } = config.repo;
-                    await RepoTaskMethods.fetchPr(url, path, targetValue, local);
+                    const prLocal = 'pr_temp_branch';
+                    await RepoTaskMethods.fetchPr(url, path, targetValue, prLocal);
                     // Get the commit ID of the fetched PR branch
-                    await bash('git', ['rev-parse', local], {
+                    await bash('git', ['rev-parse', prLocal], {
                         cwd: path,
                     }, (chunk) => {
                         const log = `${chunk}`;

--- a/source/internal/repo.ts
+++ b/source/internal/repo.ts
@@ -189,23 +189,11 @@ export class RepoTask extends Task {
                     return TaskState.error;
                 }
             } else if (config.repo.targetType === 'commit') {
-                try {
-                    await bash('git', ['rev-parse', config.repo.targetValue], {
-                        cwd: path,
-                    }, (chunk) => {
-                        const log = `${chunk}`;
-                        remoteID = log.replace(/\n/g, '').trim();
-                    });
-                } catch (error) {
-                    const err = error as Error;
-                    task.print('Failed to fetch remote commit [ git rev-parse commit ]');
-                    task.print(err.message);
-                    return TaskState.error;
-                }
+                remoteID = config.repo.targetValue;
             } else if (config.repo.targetType === 'pr') {
                 try {
                     const {
-                        url, targetValue, local,
+                        url, targetValue,
                     } = config.repo;
                     const prLocal = 'pr_temp_branch';
                     await RepoTaskMethods.fetchPr(url, path, targetValue, prLocal);


### PR DESCRIPTION
<!-- 请勿删除注释，需要使用时请复制一遍 -->
## PR 类型

- [x] 问题修复
- [ ] 优化
- [ ] 新功能
- [ ] 测试用例

<!-- 详细的描述这个修改的背景和原因 -->
## PR 描述

<!-- 请描述具体改动了哪些地方，为什么修改 -->
### 修改说明
1.  这个仓库的机制是先获取需要切的 commit 再去切换到对应的 commit ，在不更改原始流程的情况下，pr 统一拉取到一个临时分支，再走原来的机制切换 commit 
